### PR TITLE
build-base instead of gcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN \
   apk add \
     --no-cache \
     --no-progress \
+    build-base \
     curl \
-    gcc \
     git \
     grep \
     jq \

--- a/Dockerfile.circleci
+++ b/Dockerfile.circleci
@@ -11,8 +11,8 @@ RUN \
     --no-cache \
     --no-progress \
     bash \
+    build-base \
     curl \
-    gcc \
     git \
     grep \
     jq \


### PR DESCRIPTION
Following up on #2, `build-base` is better than `gcc` since it includes header files and `libc-dev`