### PR TITLE
Add script to consistently tag and push Docker images

### DIFF
--- a/Dockerfile.circleci
+++ b/Dockerfile.circleci
@@ -4,8 +4,6 @@ ENV \
   HELM_VERSION=2.9.1 \
   KUBECTL_VERSION=1.10.5
 
-ADD circleci/setup-kube-auth /usr/local/bin/setup-kube-auth
-
 RUN \
   apk add \
     --no-cache \
@@ -27,5 +25,7 @@ RUN \
   && git clone https://github.com/AGWA/git-crypt.git \
   && cd git-crypt && make && make install && cd - && rm -rf git-crypt \
   && chmod +x /usr/local/bin/*
+
+COPY circleci/setup-kube-auth /usr/local/bin/setup-kube-auth
 
 ENTRYPOINT ["/usr/local/bin/setup-kube-auth"]

--- a/Dockerfile.circleci
+++ b/Dockerfile.circleci
@@ -27,5 +27,6 @@ RUN \
   && chmod +x /usr/local/bin/*
 
 COPY circleci/setup-kube-auth /usr/local/bin/setup-kube-auth
+COPY circleci/tag-and-push-docker-image /usr/local/bin/tag-and-push-docker-image
 
 ENTRYPOINT ["/usr/local/bin/setup-kube-auth"]

--- a/circleci/tag-and-push-docker-image
+++ b/circleci/tag-and-push-docker-image
@@ -44,7 +44,7 @@ function tag_and_push() {
 built_tag="$1"
 docker_repository="$2"
 
-if [ -z "$built_tag" -o -z "$docker_repository" ]; then
+if [ -z "$built_tag" ] || [ -z "$docker_repository" ]; then
   usage
   exit 1
 fi

--- a/circleci/tag-and-push-docker-image
+++ b/circleci/tag-and-push-docker-image
@@ -50,7 +50,7 @@ if [ -z "$built_tag" ] || [ -z "$docker_repository" ]; then
 fi
 
 safe_git_branch=${CIRCLE_BRANCH//\//-}
-short_sha="$(git rev-parse --short=7 $CIRCLE_SHA1)"
+short_sha=${CIRCLE_SHA1:0:7}
 
 if [ "$CIRCLE_BRANCH" == "master" ]; then
   tag_and_push "$docker_repository:$CIRCLE_SHA1"

--- a/circleci/tag-and-push-docker-image
+++ b/circleci/tag-and-push-docker-image
@@ -36,8 +36,8 @@ function tag_and_push() {
   tag="$1"
   echo
   echo "Tagging and pushing $tag..."
-  docker tag $built_tag $tag
-  docker push $tag
+  docker tag "$built_tag" "$tag"
+  docker push "$tag"
 }
 
 

--- a/circleci/tag-and-push-docker-image
+++ b/circleci/tag-and-push-docker-image
@@ -1,0 +1,60 @@
+#!/bin/sh -e
+
+function usage() {
+  echo
+  cat <<EOF
+Usage: $0 <built image tag> <remote docker image>
+
+  This script will take the git branch name and git SHA1 from CircleCI and create and push tags
+  to the given remote Docker repository.
+
+  On the "master" branch, it will create and push the following tags:
+
+    - <remote docker image>:SHA1
+    - <remote docker image>:branch_name.short_SHA1
+    - <remote docker image>:branch_name
+
+  On feature branches, it will create and push the following tags:
+
+    - <remote docker image>:branch_name.short_SHA1
+    - <remote docker image>:branch_name
+
+Examples:
+
+  $ docker build . --tag=app
+  <snip>
+  Successfully tagged app:latest
+
+  $ tag-and-push-docker-image app 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-fala
+  Tagging and pushing 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-fala:502f1c2d82a2c12d70482b1361a0d46e875a7b51...
+  Tagging and pushing 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-fala:master.502f1c2...
+  Tagging and pushing 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-fala:master...
+EOF
+}
+
+function tag_and_push() {
+  tag="$1"
+  echo
+  echo "Tagging and pushing $tag..."
+  docker tag $built_tag $tag
+  docker push $tag
+}
+
+
+built_tag="$1"
+docker_repository="$2"
+
+if [ -z "$built_tag" -o -z "$docker_repository" ]; then
+  usage
+  exit 1
+fi
+
+safe_git_branch=${CIRCLE_BRANCH//\//-}
+short_sha="$(git rev-parse --short=7 $CIRCLE_SHA1)"
+
+if [ "$CIRCLE_BRANCH" == "master" ]; then
+  tag_and_push "$docker_repository:$CIRCLE_SHA1"
+fi
+
+tag_and_push "$docker_repository:$safe_git_branch.$short_sha"
+tag_and_push "$docker_repository:$safe_git_branch"

--- a/circleci/tag-and-push-docker-image
+++ b/circleci/tag-and-push-docker-image
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 function usage() {
   echo


### PR DESCRIPTION
## What does this pull request do?

This changeset adds a reusable script that intends to provide a consistent way to tag and push applications built in CircleCI.

### Tagging strategy

Assuming we are building the `502f1c2d82a2c12d70482b1361a0d46e875a7b51` commit on the `master` branch, the script would tag:

```
<remote>:502f1c2d82a2c12d70482b1361a0d46e875a7b51
<remote>:master.502f1c2
<remote>:master
```

On any other branch, it would not include the full git SHA1:

```
<remote>:nginx.84ca837
<remote>:nginx
```

We found this naming strategy suitable as:

- Full git SHA1s are hard to clean up from the Docker repository as we do not know which build they refer to. For this reason, we only tag them on "production deployable" builds.
- Tagging the 7-character short git SHA1 after the branch is useful in Kubernetes. If we only had `:feature-branch` deployed it would be hard to deploy a subsequent change on the branch as the deployment would not change.
- Finally, tagging the branch name is useful for any other usage if we want to pull down the latest version of "master" or any other branch.

## Any other changes that would benefit highlighting?

Please see the usage in [`circleci/tag-and-push-docker-image`](https://github.com/sldblog/cloud-platform-tools-image/blob/docker-tag-script/circleci/tag-and-push-docker-image).

## Any other context?

We already use this script (or equivalent) in:

- https://github.com/ministryofjustice/fala/pull/14
- https://github.com/ministryofjustice/laa-legal-adviser-api/pull/67
- https://github.com/ministryofjustice/cla_frontend/pull/625
- https://github.com/ministryofjustice/cla_backend/pull/478
- https://github.com/ministryofjustice/cla_public/pull/761

We aim to reduce duplication by moving it here to be useful everywhere.