### PR TITLE
Add script to consistently notify Slack after deployments

### DIFF
--- a/Dockerfile.circleci
+++ b/Dockerfile.circleci
@@ -26,7 +26,6 @@ RUN \
   && cd git-crypt && make && make install && cd - && rm -rf git-crypt \
   && chmod +x /usr/local/bin/*
 
-COPY circleci/setup-kube-auth /usr/local/bin/setup-kube-auth
-COPY circleci/tag-and-push-docker-image /usr/local/bin/tag-and-push-docker-image
+COPY circleci/* /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/setup-kube-auth"]

--- a/circleci/notify-slack-after-deployment
+++ b/circleci/notify-slack-after-deployment
@@ -1,0 +1,60 @@
+#!/bin/bash -e
+
+function usage() {
+  cat <<-EOF
+
+Usage: $0 <target environment> <Slack webhook url>
+
+  This script will notify Slack that the "commit URL" has been deployed to the "target environment".
+
+  The commit URL is a link to the deployed commit in GitHub.
+  The notification will contain a link to the CircleCI build doing the deploy.
+
+Example:
+
+  # If the active project is "FALA" and the commit is "5a42eb3"
+  $ notify-slack-after-deployment staging
+  ok
+
+Will produce:
+
+  :tada: Deployed https://github.com/ministryofjustice/fala/commit/5a42eb3 to *staging*
+  <View build>
+
+  The "view build" button will link to https://circleci.com/gh/ministryofjustice/fala/191.
+
+Requires the following environment variables:
+
+  - \$CIRCLE_BUILD_URL
+  - \$CIRCLE_PROJECT_REPONAME
+  - \$CIRCLE_PROJECT_USERNAME
+  - \$CIRCLE_SHA1
+EOF
+}
+
+target_environment="$1"
+webhook_url="$2"
+if [ -z "$target_environment" ] || [ -z "$webhook_url" ]; then
+  usage
+  exit 1
+fi
+
+github_repo_url="https://github.com/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_PROJECT_USERNAME}"
+build_url="$CIRCLE_BUILD_URL"
+short_sha=${CIRCLE_SHA1:0:7}
+
+payload_file="$(mktemp)"
+cat <<END >"$payload_file"
+{
+  "text": ":tada: Deployed \`${github_repo_url}/commit/$short_sha\` to *$target_environment*.",
+  "attachments": [
+    {
+      "fallback": "<$build_url|View build>",
+      "actions": [{"type": "button", "text": "View build", "url": "$build_url"}]
+    }
+  ]
+}
+END
+
+jq . < "$payload_file"
+curl --request POST --data @"$payload_file" --header "Content-Type: application/json" "$webhook_url"


### PR DESCRIPTION
## What does this pull request do?

This changeset adds a reusable script that intends to provide a consistent way to notify teams about application deployments executed from CircleCI.

### Notification sample

Assuming we are deploying https://github.com/ministryofjustice/fala/commit/5a42eb3bed31993302533e7e981b56fc79ed07f4 in https://circleci.com/gh/ministryofjustice/fala/191, the script will produce the following notification (with our webhook URL):

<img width="677" alt="screen shot 2018-10-31 at 17 19 01" src="https://user-images.githubusercontent.com/1526295/47806215-188f9880-dd31-11e8-8708-66fec87d38f4.png">

The "View build" button would link to the [CircleCI job](https://circleci.com/gh/ministryofjustice/fala/191).

### Caveats

- The script's target channel depends on the Slack webhook URL.