### PR TITLE
Add core, find and util-linux installs to tools Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,15 @@ RUN \
     bash \
     build-base \
     ca-certificates \
+    coreutils \
     curl \
     docker \
+    findutils \
     git \
     grep \
     jq \
     python3 \
+    util-linux \
   && pip3 install --upgrade pip \
   && pip3 install awscli \
   && curl -sLo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \


### PR DESCRIPTION
This change allows the team to use a core Linux version of commands such as 'find' and 'xargs' and avoid using the busybox image tools. Connects to https://github.com/ministryofjustice/cloud-platform/issues/334

**WHAT**
---
- Three additional packages to install upon build. 

**WHY**
---
- Will allow the team to use core Linux commands such as `find` and avoid using the BusyBox versions.