### PR TITLE
Remove the Docker package from the main tools image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN \
     ca-certificates \
     coreutils \
     curl \
-    docker \
     findutils \
     git \
     grep \


### PR DESCRIPTION
All Docker related tasks should be done in the tools:circleci image