### PR TITLE
Use Helm 2.14.3 instead of 2.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN go get -v github.com/russellcardullo/terraform-provider-pingdom
 FROM alpine:3.7
 
 ENV \
-  HELM_VERSION=2.11.0 \
+  HELM_VERSION=2.14.3 \
   KOPS_VERSION=1.10.1 \
   KUBECTL_VERSION=1.11.10 \
   TERRAFORM_VERSION=0.11.14 \

--- a/Dockerfile.circleci
+++ b/Dockerfile.circleci
@@ -1,7 +1,7 @@
 FROM docker:18.05.0-ce-git
 
 ENV \
-  HELM_VERSION=2.11.0 \
+  HELM_VERSION=2.14.3 \
   KUBECTL_VERSION=1.11.10
 
 RUN \


### PR DESCRIPTION
When running the cluster build script via the tools image, we
noticed intermittent failures with prometheus and cert-manager.

The working theory is that custom resource definitions (CRDs) were
sometimes not ready, when they were referenced, perhaps because
the build process was running a little slower, via a docker
container.

Helm 2.14 is reportedly better at handling CRDs than previous
versions, and two test builds in a row were successful, when using
Helm 2.14.

For this reason, and because it's generally good practice to keep
our tools reasonably up to date, this commit upgrades helm to the
latest version.

Note: users who try to use this version of helm to talk to older
tiller installations may be prompted to upgrade their tiller.