### PR TITLE
Add and switch to a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,15 @@ ENV \
   KOPS_VERSION=1.10.1 \
   KUBECTL_VERSION=1.11.10 \
   TERRAFORM_VERSION=0.11.14 \
-  TERRAFORM_AUTH0_VERSION=0.1.18
+  TERRAFORM_AUTH0_VERSION=0.1.18 \
+  USER=toolsuser \
+  UID=1002 \
+  GROUP=toolsgroup
+
+ENV HOME=/home/${USER}
+
+RUN addgroup -g ${UID} -S ${GROUP} && \
+    adduser -u ${UID} -S ${USER} -G ${GROUP}
 
 RUN \
   apk add \
@@ -41,9 +49,12 @@ RUN \
   && curl -sL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | unzip -d /usr/local/bin - \
   && chmod +x /usr/local/bin/* \
   && curl -sL https://github.com/yieldr/terraform-provider-auth0/releases/download/v${TERRAFORM_AUTH0_VERSION}/terraform-provider-auth0_v${TERRAFORM_AUTH0_VERSION}_linux_amd64.tar.gz | tar xzv  \
-  && mkdir -p ~/.terraform.d/plugins \
-  && mv terraform-provider-auth0_v${TERRAFORM_AUTH0_VERSION} ~/.terraform.d/plugins/ \
+  && mkdir -p ${HOME}/.terraform.d/plugins \
+  && mv terraform-provider-auth0_v${TERRAFORM_AUTH0_VERSION} ${HOME}/.terraform.d/plugins/ \
   && git clone https://github.com/AGWA/git-crypt.git \
   && cd git-crypt && make && make install && cd - && rm -rf git-crypt
 
-COPY --from=pingdom_builder /go/bin/terraform-provider-pingdom /root/.terraform.d/plugins/
+COPY --from=pingdom_builder /go/bin/terraform-provider-pingdom ${HOME}/.terraform.d/plugins/
+
+USER ${UID}
+WORKDIR ${HOME}


### PR DESCRIPTION
The kubernetes cluster will not allow containers
whose user is running as root.

This commit changes the tools image so that it
runs as a non-root user.

Note: to use this image to build a cluster, AWS &
gpg credentials need to be mounted into
/home/toolsuser, not /root

Also, the infrastructure repository code needs to
be mounted into a directory below /home/toolsuser,
not directly into /home/toolsuser. Otherwise, you
end up nuking /home/toolsuser/.terraform.d and the
auth0 plugin, which breaks the cluster build script.