### PR TITLE
Grant ownership of ${HOME} to the toolsuser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,5 +56,7 @@ RUN \
 
 COPY --from=pingdom_builder /go/bin/terraform-provider-pingdom ${HOME}/.terraform.d/plugins/
 
+RUN chown -R ${USER}:${GROUP} ${HOME}
+
 USER ${UID}
 WORKDIR ${HOME}


### PR DESCRIPTION
Without this, the toolsuser could not run terraform init for the
concourse pipeline, because it cannot write to ${HOME}/.terraform.d