### PR TITLE
Add a makefile to build and push to docker hub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.built-image

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The repository produces two images:
   - `kubectl`
 
 ## Tagging
+
 Docker images are tagged using the git commit SHA and are available at `754256621582.dkr.ecr.eu-west-2.amazonaws.com/cloud-platform/tools`.
 
 For the base image, the latest version is also tagged as `latest`.
@@ -28,6 +29,7 @@ For the CircleCI images, the git commit SHA is suffixed with `-circleci`, the la
 The CircleCI image is based on the upstream `docker` image and includes `setup-kube-auth` (also set as the entrypoint) which aims to simplify using `kubectl` on CircleCI.
 
 For each "environment" (kuberenetes context) that's required in CircleCI, it expects to find the following environment variables:
+
 - `KUBE_ENV_XYZ_NAME`, the name of the cluster (which also determines its host)
 - `KUBE_ENV_XYZ_NAMESPACE`, the namespace to target in that cluster
 - `KUBE_ENV_XYZ_CACERT` and`KUBE_ENV_XYZ_TOKEN`, from [ServiceAccount][how-to-serviceaccount]

--- a/makefile
+++ b/makefile
@@ -1,0 +1,16 @@
+# This file is a temporary measure whilst moving the tools image from
+# an AWS ECR to Docker Hub.
+#
+# Ultimately, this should be done by concourse, and this makefile can
+# be removed.
+
+build: .built-image
+
+push:
+	docker tag cloud-platform-tools ministryofjustice/cloud-platform-tools
+	docker push ministryofjustice/cloud-platform-tools
+
+.built-image: Dockerfile
+	docker build -t cloud-platform-tools .
+	make push
+	touch .built-image


### PR DESCRIPTION
This is an interim step to make the image available, so that we can update
the user guide to enable users to create namespaces using the tools image.

Ultimately, building and pushing the image should happen via concourse, so
there should be no need to build and push manually.