### PR TITLE
Add the octokit gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,8 @@ RUN mkdir -p /app/integration-test/; cd /app/integration-test \
       https://raw.githubusercontent.com/ministryofjustice/cloud-platform-infrastructure/master/smoke-tests/Gemfile.lock \
       \
       && gem install bundler \
-      && bundle install
+      && bundle install \
+      && gem install octokit
 
 COPY --from=pingdom_builder /go/bin/terraform-provider-pingdom /root/.terraform.d/plugins/
 

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 IMAGE := ministryofjustice/cloud-platform-tools
-TAG := 1.4
+TAG := 1.5
 
 # This image is built and pushed via a concourse pipeline:
 #


### PR DESCRIPTION
This gem is used by our github actions. Every action we have
installs the octokit gem during its setup.

This commit adds the octokit gem to the tools image, so that this
step will no longer be necessary.

After this commit is merged, the tool-image pipeline should be
updated to tag the image as version 1.5