### PR TITLE
Update kubectl on the Circle CI image

### DIFF
--- a/Dockerfile.circleci
+++ b/Dockerfile.circleci
@@ -2,7 +2,7 @@ FROM docker:18.05.0-ce-git
 
 ENV \
   HELM_VERSION=2.14.3 \
-  KUBECTL_VERSION=1.11.10
+  KUBECTL_VERSION=1.13.11
 
 RUN \
   apk add \


### PR DESCRIPTION
Sets the Kubectl version on the circle ci image to 1.13, the same as on the main image