### PR TITLE
Install v. 0.12.13 as /usr/bin/local/terraform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ ENV \
   KUBECTL_VERSION=1.13.11 \
   TERRAFORM_AUTH0_VERSION=0.2.1 \
   TERRAFORM_PINGDOM_VERSION=1.1.1 \
-  TERRAFORM_VERSION=0.11.14 \
-  TERRAFORM12_VERSION=0.12.13
+  TERRAFORM_VERSION=0.12.13
 
 RUN \
   apk add \
@@ -77,9 +76,6 @@ RUN curl -sL https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION
 
 # Install terraform
 RUN curl -sL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | unzip -d /usr/local/bin -
-
-# Install terraform 12
-RUN curl -sL https://releases.hashicorp.com/terraform/${TERRAFORM12_VERSION}/terraform_${TERRAFORM12_VERSION}_linux_amd64.zip | unzip - && mv terraform /usr/local/bin/terraform12
 
 # Ensure everything is executable
 RUN chmod +x /usr/local/bin/*

--- a/makefile
+++ b/makefile
@@ -20,3 +20,12 @@ tag:
 push: .built-docker-image
 	docker tag $(IMAGE) $(IMAGE):$(TAG)
 	docker push $(IMAGE):$(TAG)
+
+shell:
+	docker run --rm -it \
+		-v $$(pwd):/app \
+		-v $${HOME}/.kube:/app/.kube \
+		-e KUBECONFIG=/app/.kube/config \
+		-v $${HOME}/.aws:/root/.aws \
+		-v $${HOME}/.gnupg:/root/.gnupg \
+		-w /app $(IMAGE) bash

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 IMAGE := ministryofjustice/cloud-platform-tools
-TAG := 1.6
+TAG := 1.7
 
 # This image is built and pushed via a concourse pipeline:
 #


### PR DESCRIPTION
Now that we have completed the upgrade of all our
terraform code, we only need terraform 0.12 in the
tools image.

blocks https://github.com/ministryofjustice/cloud-platform-environments/pull/1677