### PR TITLE
Add the 'circleci' shell commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,4 +96,9 @@ RUN wget https://github.com/russellcardullo/terraform-provider-pingdom/releases/
   && chmod +x terraform-provider-pingdom_v${TERRAFORM_PINGDOM_VERSION}_linux_amd64_static \
   && mv terraform-provider-pingdom_v${TERRAFORM_PINGDOM_VERSION}_linux_amd64_static ~/.terraform.d/plugins/terraform-provider-pingdom_v${TERRAFORM_PINGDOM_VERSION}
 
+# Copy utility commands for teams who use this image as part
+# of their CI pipelines
+COPY circleci/setup-kube-auth /usr/local/bin/setup-kube-auth
+COPY circleci/tag-and-push-docker-image /usr/local/bin/tag-and-push-docker-image
+
 CMD /bin/bash

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 IMAGE := ministryofjustice/cloud-platform-tools
-TAG := 1.6
+TAG := 1.8
 
 # This image is built and pushed via a concourse pipeline:
 #


### PR DESCRIPTION
We have our main tools image on docker hub, but a couple of teams
are using a slightly different version, pushed to ECR by a
concourse pipeline.

The 'circleci' version includes a couple of shell scripts to aid
in authenticating to the cluster and pushing docker images. One or
two teams are using this version (based on a github search for the
ECR docker image reference).

This change adds these shell scripts to our 'official' tools image
so that anyone using it can use our version from docker hub,
instead of the ECR version (which will subsequently be removed,
along with the pipeline job that creates it).