### PR TITLE
aws-iam-authenticator binary added (for EKS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,9 @@ RUN curl -sL https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION
 # Install terraform
 RUN curl -sL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | unzip -d /usr/local/bin -
 
+# Install aws-iam-authenticator (required for EKS)
+RUN curl -sLo /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator
+
 # Ensure everything is executable
 RUN chmod +x /usr/local/bin/*
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The repository produces two images:
   - `postgresql-client`
   - `ruby`
   - `terraform`
+  - `aws-iam-authenticator`
 - the CircleCI build image includes:
   - `aws`
   - `helm`

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 IMAGE := ministryofjustice/cloud-platform-tools
-TAG := 1.9
+TAG := 1.10
 
 # This image is built and pushed via a concourse pipeline:
 #


### PR DESCRIPTION
In order to authenticate to EKS (using aws-cli) we need to have aws-iam-authenticator installed. This PR adds the binary to the tools-image