### PR TITLE
Added cp-tools CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM golang:1.12.2-alpine3.9 as cp_tools_builder
 RUN apk add git make
 RUN \
     git clone https://github.com/ministryofjustice/cloud-platform-tools.git && \
-    cd cloud-platform-tools/cmd && \
+    cd cloud-platform-tools/cmd/cp-tools && \
     CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o cp-tools .
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,15 @@ RUN \
     cd terraform-provider-concourse && \
     make build
 
+# Build Cloud Platform tools (CLI)
+FROM golang:1.12.2-alpine3.9 as cp_tools_builder
+RUN apk add git make
+RUN \
+    git clone https://github.com/ministryofjustice/cloud-platform-tools.git && \
+    cd cloud-platform-tools/cmd && \
+    CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o cp-tools .
+
+
 FROM ruby:2.6.3-alpine
 
 ENV \
@@ -60,6 +69,7 @@ RUN mkdir -p /app/integration-test/; cd /app/integration-test \
       && bundle install
 
 COPY --from=concourse_builder /go/terraform-provider-concourse /root/.terraform.d/plugins/
+COPY --from=cp_tools_builder /go/cloud-platform-tools/cmd/cp-tools /usr/local/bin/cp-tools
 
 # Install git-crypt
 RUN git clone https://github.com/AGWA/git-crypt.git \


### PR DESCRIPTION
This change builds `cp-tools` in a separate container and copies the artefact (just 5MB) to the docker tools image.  

`cp-tools` is a Golang CLI created to be used for multiple purposes. As the initial release, it includes terraform subcommands for verifying terraform divergences.

