### PR TITLE
Pin gov.uk concourse provider to v5.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.14.4-alpine3.12 as concourse_builder
 RUN apk add git make
 RUN \
-    git clone https://github.com/alphagov/terraform-provider-concourse.git && \
+    git clone https://github.com/alphagov/terraform-provider-concourse.git --branch v5.8.0 && \
     cd terraform-provider-concourse && \
     make build
 

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 IMAGE := ministryofjustice/cloud-platform-tools
-TAG := 1.17
+TAG := 1.18
 
 # This image is built and pushed via a concourse pipeline:
 #


### PR DESCRIPTION
We were building the concourse provider from master, but this breaks our
apply pipeline for 'gitops' namespaces.

This change pins the concourse provider to an earlier release, which we
hope will solve the issue.