### PR TITLE
Use github actions to build the tools image

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -1,0 +1,20 @@
+name: Publish docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push image to docker hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Push image to docker hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ministryofjustice/cloud-platform-tools
+          tag_with_ref: true

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# cloud-platform-tools-image
+# MoJ Cloud Platform 'tools' image
 
-The repository produces two images:
+A docker image with a set of useful software tools installed, for managing the cloud platform.
 
-- the main image includes:
+The image includes:
+
   - `aws`
   - `git-crypt`
   - `helm`
@@ -13,23 +14,20 @@ The repository produces two images:
   - `ruby`
   - `terraform`
   - `aws-iam-authenticator`
-- the CircleCI build image includes:
-  - `aws`
-  - `helm`
-  - `kubectl`
+  - `setup-kube-auth`
+  - `tag-and-push-docker-image`
 
-## Tagging
+## Building and tagging the tools image
 
-Docker images are tagged using the git commit SHA and are available at [DockerHub](https://hub.docker.com/r/ministryofjustice/cloud-platform-tools)
+A github action builds the tools image and pushes it to [DockerHub](https://hub.docker.com/r/ministryofjustice/cloud-platform-tools) whenever a new release is defined in github.
 
-For the base image, the latest version is also tagged as `latest`.
-For the CircleCI images, the git commit SHA is suffixed with `-circleci`, the latest version is tagged as `circleci`.
+The image is tagged with the release number.
 
-## CircleCI
+## setup-kube-auth
 
-The CircleCI image is based on the upstream `docker` image and includes `setup-kube-auth` (also set as the entrypoint) which aims to simplify using `kubectl` on CircleCI.
+This is a bash script that automates the process of authenticating to the cloud platform, for use in automated build pipelines.
 
-For each "environment" (kuberenetes context) that's required in CircleCI, it expects to find the following environment variables:
+For each "environment" (kuberenetes context) that's required in your build pipeline, the script expects to find the following environment variables:
 
 - `KUBE_ENV_XYZ_NAME`, the name of the cluster (which also determines its host)
 - `KUBE_ENV_XYZ_NAMESPACE`, the namespace to target in that cluster
@@ -37,4 +35,8 @@ For each "environment" (kuberenetes context) that's required in CircleCI, it exp
 
 It will configure `kubectl` with a context named `xyz`.
 
-[how-to-serviceaccount]: https://user-guide.cloud-platform.service.justice.gov.uk/tasks.html#creating-a-service-account-for-circleci
+## tag-and-push-docker-image
+
+This is a script to simplify the process of pushing a service team's docker image to DockerHub, and tagging it with the SHA1 of the latest commit.
+
+[how-to-serviceaccount]: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/using-circleci-for-continuous-deployment.html#creating-a-service-account-for-circleci

--- a/makefile
+++ b/makefile
@@ -1,25 +1,7 @@
-IMAGE := ministryofjustice/cloud-platform-tools
-TAG := 1.17
-
-# This image is built and pushed via a concourse pipeline:
+# This image is built and pushed via a github action
 #
-# https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/tools-image/jobs/build-cp
+# See .github/workflows/docker-hub.yml
 #
-# So, it should not normally be necessary to use the build process defined here.
-#
-
-build: .built-docker-image
-
-.built-docker-image: Dockerfile makefile
-	docker build -t $(IMAGE) .
-	touch .built-docker-image
-
-tag:
-	docker tag $(IMAGE) $(IMAGE):$(TAG)
-
-push: .built-docker-image
-	make tag
-	docker push $(IMAGE):$(TAG)
 
 shell:
 	docker run --rm -it \
@@ -28,4 +10,4 @@ shell:
 		-e KUBECONFIG=/app/.kube/config \
 		-v $${HOME}/.aws:/root/.aws \
 		-v $${HOME}/.gnupg:/root/.gnupg \
-		-w /app $(IMAGE) bash
+		-w /app ministryofjustice/cloud-platform-tools bash


### PR DESCRIPTION
Because it's better than having to do it manually.