### PR TITLE
Add the docker cli to the tools image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN \
     python3 \
     ruby-dev \
     util-linux \
+    docker-cli \
   \
   && pip3 install --upgrade pip \
   && pip3 install pygithub boto3 \


### PR DESCRIPTION
Many service teams use the tools image in their CI/CD pipelines, but the
version they use (the deprecated "circleci" tag) made the "docker"
command available. Without this, teams can't use the image for this
purpose.

This command adds the `docker` cli tool to the image, which should mean
teams can use the maintained, latest version, rather than an outdated
deprecated version of the image.
