### PR TITLE
Create a "pipeline-tools-image"

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -11,11 +11,19 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: Push image to docker hub
+      - name: Push tools image to docker hub
         uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: ministryofjustice/cloud-platform-tools
           tags: latest
+          tag_with_ref: true
+      - name: Push pipeline-tools image to docker hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          dockerfile: Dockerfile.cp-env-pipeline
+          repository: ministryofjustice/cloud-platform-pipeline-tools
           tag_with_ref: true

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -17,4 +17,5 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: ministryofjustice/cloud-platform-tools
+          tags: latest
           tag_with_ref: true

--- a/Dockerfile.cp-env-pipeline
+++ b/Dockerfile.cp-env-pipeline
@@ -1,0 +1,13 @@
+# This is a version of the tools image which has the ruby gems which the
+# environments pipelines (apply, plan, and apply-changes) require
+# pre-installed.
+#
+# Pre-installing these gems cuts between 1 and 2 minutes from every
+# environments pipeline run, and so speeds things up significantly.
+
+FROM ministryofjustice/cloud-platform-tools:latest
+
+RUN wget https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/main/Gemfile \
+    && wget https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/main/Gemfile.lock \
+    && bundle config set without development test \
+    && bundle install


### PR DESCRIPTION
Add a "cloud-platform-pipeline-tools" docker image to speed up the environments concourse pipeline jobs (by 1 - 2 minutes per job).

- Change add "latest" tag to tools image
- Build and push a second image to docker hub

fixes https://github.com/ministryofjustice/cloud-platform/issues/2315
