### PR TITLE
Remove Terraform 0.13 and only use 0.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,9 +70,8 @@ RUN curl -sLo /usr/local/bin/kops https://github.com/kubernetes/kops/releases/do
 # Install helm
 RUN curl -L https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helm && rm -rf linux-amd64
 
-# Install Terraform versions for upgrade
-COPY --from=hashicorp/terraform:0.13.6 /bin/terraform /usr/local/bin/terraform0.13
-COPY --from=hashicorp/terraform:0.14.7 /bin/terraform /usr/local/bin/terraform0.14
+# Install Terraform
+COPY --from=hashicorp/terraform:0.14.7 /bin/terraform /usr/local/bin/terraform
 
 # Install aws-iam-authenticator (required for EKS)
 RUN curl -sLo /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator


### PR DESCRIPTION
Overview
---
The upgrade work is complete. I will make a note of this change for future upgrade work.