### PR TITLE
perf(infra): add go mod and sum file init for faster tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,10 @@ RUN mkdir -p /app/integration-test/; cd /app/integration-test \
       && wget \
       https://raw.githubusercontent.com/ministryofjustice/cloud-platform-infrastructure/main/smoke-tests/Gemfile \
       https://raw.githubusercontent.com/ministryofjustice/cloud-platform-infrastructure/main/smoke-tests/Gemfile.lock \
+      https://raw.githubusercontent.com/ministryofjustice/cloud-platform-infrastructure/restructure-tests/go.mod \
+      https://raw.githubusercontent.com/ministryofjustice/cloud-platform-infrastructure/restructure-tests/go.sum \
       \
+		&& go mod download \
       && gem install bundler \
       && bundle install
 


### PR DESCRIPTION
when running integration tests in the infrastructure repository they tend to take a really long time due to dependency download. This change pulls them down at build so we don't end up expensively pulling them each test run (~1hr)
