### PR TITLE
Add infrastructure specific Dockerfile

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -27,3 +27,11 @@ jobs:
           dockerfile: Dockerfile.cp-env-pipeline
           repository: ministryofjustice/cloud-platform-pipeline-tools
           tag_with_ref: true
+      - name: Push infrastructure-tools image to docker hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          dockerfile: Dockerfile.cp-infrastructure
+          repository: ministryofjustice/cloud-platform-infrastructure
+          tag_with_ref: true

--- a/Dockerfile.cp-infrastructure
+++ b/Dockerfile.cp-infrastructure
@@ -1,0 +1,11 @@
+# This image pulls the latest tools image and builds with the cloud-platform-infrastructure
+# dependencies built in. This makes this image smaller but reduces test runtime by half.
+
+FROM ministryofjustice/cloud-platform-tools:latest
+
+RUN mkdir -p /app/integration-test/; cd /app/integration-test \
+      && wget \
+      https://raw.githubusercontent.com/ministryofjustice/cloud-platform-infrastructure/restructure-tests/go.mod \
+      https://raw.githubusercontent.com/ministryofjustice/cloud-platform-infrastructure/restructure-tests/go.sum \
+      \
+		&& go mod download


### PR DESCRIPTION
Overview
---

This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/3482 and relates to the requirement to build and run the Cloud Platform infrastructure tests.

> Why not just use the main tools image?

When running tests in the tools image you can execute `go test ./...` which then proceeds to download all modules, which takes about ten minutes. This also adds about 500MB onto the static size of the image. The choices therefore are to either bake them into the image, or wait for the module download upon each test.

After a discussion with the team another potential solution was devised. Create another docker image that uses tools as a basis and then bakes the deps into a separate image.
