### PR TITLE
Add ginkgo install to infra dockerfile

### DIFF
--- a/Dockerfile.cp-infrastructure
+++ b/Dockerfile.cp-infrastructure
@@ -9,3 +9,8 @@ RUN mkdir -p /app/integration-test/; cd /app/integration-test \
       https://raw.githubusercontent.com/ministryofjustice/cloud-platform-infrastructure/restructure-tests/go.sum \
       \
 		&& go mod download
+
+RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo \
+	   go get github.com/onsi/gomega/...
+
+ENV PATH="/root/go/bin:${PATH}"

--- a/Dockerfile.cp-infrastructure
+++ b/Dockerfile.cp-infrastructure
@@ -1,15 +1,17 @@
 # This image pulls the latest tools image and builds with the cloud-platform-infrastructure
-# dependencies built in. This makes this image smaller but reduces test runtime by half.
-
+# dependencies built in. This makes this image larger but reduces test runtime by half.
 FROM ministryofjustice/cloud-platform-tools:latest
 
+# Download the main branch of Cloud Platform dependencies.
+# Warning: This will take a long time.
 RUN mkdir -p /app/integration-test/; cd /app/integration-test \
       && wget \
-      https://raw.githubusercontent.com/ministryofjustice/cloud-platform-infrastructure/restructure-tests/go.mod \
-      https://raw.githubusercontent.com/ministryofjustice/cloud-platform-infrastructure/restructure-tests/go.sum \
+      https://raw.githubusercontent.com/ministryofjustice/cloud-platform-infrastructure/main/go.mod \
+      https://raw.githubusercontent.com/ministryofjustice/cloud-platform-infrastructure/main/go.sum \
       \
 		&& go mod download
 
+# Install Ginkgo for fast integration test feedback.
 RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo \
 	   go get github.com/onsi/gomega/...
 


### PR DESCRIPTION
Overview
---

This enables us realtime response of how go tests are performing. Fast feedback is useful for many reasons, but mainly because of the current slow speed of execution.
