### PR TITLE
Ginkgo version change | v2 to v1

### DIFF
--- a/Dockerfile.cp-infrastructure
+++ b/Dockerfile.cp-infrastructure
@@ -11,8 +11,7 @@ RUN mkdir -p /app/integration-test/; cd /app/integration-test \
       \
 		&& go mod download
 
-# Install Ginkgo for fast integration test feedback.
-RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo \
-	   go get github.com/onsi/gomega/...
+# Install Ginkgo binary for fast integration test feedback.
+RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
 
 ENV PATH="/root/go/bin:${PATH}"

--- a/Dockerfile.cp-infrastructure
+++ b/Dockerfile.cp-infrastructure
@@ -12,6 +12,6 @@ RUN mkdir -p /app/integration-test/; cd /app/integration-test \
 		&& go mod download
 
 # Install Ginkgo binary for fast integration test feedback.
-RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
+RUN go install -mod=mod github.com/onsi/ginkgo/ginkgo
 
 ENV PATH="/root/go/bin:${PATH}"


### PR DESCRIPTION
Our tests are currently running Ginkgo version 1 - we should update in due course but this should be done later.


