### PR TITLE
Bump ginkgo binary version to 2

### DIFF
--- a/Dockerfile.cp-infrastructure
+++ b/Dockerfile.cp-infrastructure
@@ -12,6 +12,6 @@ RUN mkdir -p /app/integration-test/; cd /app/integration-test \
 		&& go mod download
 
 # Install Ginkgo binary for fast integration test feedback.
-RUN go install -mod=mod github.com/onsi/ginkgo/ginkgo
+RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@latest
 
 ENV PATH="/root/go/bin:${PATH}"


### PR DESCRIPTION
the cloud-platform-infrastructure is now running ginkgo v2 - we need to update the binary in this dockerfile to match.
