### PR TITLE
Cleanup wget for smoke-test directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,15 +39,6 @@ COPY --from=golang:1.18-alpine /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 
-# Build integration test environment
-RUN mkdir -p /app/integration-test/; cd /app/integration-test \
-      && wget \
-      https://raw.githubusercontent.com/ministryofjustice/cloud-platform-infrastructure/main/smoke-tests/Gemfile \
-      https://raw.githubusercontent.com/ministryofjustice/cloud-platform-infrastructure/main/smoke-tests/Gemfile.lock \
-      \
-      && gem install bundler \
-      && bundle install
-
 # Cloud Platform CLI
 RUN URL=$(curl -sL https://api.github.com/repos/ministryofjustice/cloud-platform-cli/releases/${CLI_VERSION} | jq -r '.assets[] | select(.browser_download_url | match("linux_amd64")) | .browser_download_url') && \
     curl -sLo cli.tar.gz ${URL} && tar xzv -C /usr/local/bin -f cli.tar.gz && rm -f cli.tar.gz


### PR DESCRIPTION
this was removed a while ago and is no longer required.
