### PR TITLE
Bump golang to 1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ COPY --from=builder /usr/local/aws-cli/ /usr/local/aws-cli/
 COPY --from=builder /aws-cli-bin/ /usr/local/bin/
 
 # Install Go
-COPY --from=golang:1.19-alpine /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.21-alpine /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 


### PR DESCRIPTION
The cloud-platform-infrastructure tests have upgraded to use go 1.21. https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/go.mod#L3

This PR Bump the docker image that was used by concourse pipelines to run the tests