### PR TITLE
Bump ginkgo dependency to match the infra go.mod

### DIFF
--- a/Dockerfile.cp-infrastructure
+++ b/Dockerfile.cp-infrastructure
@@ -13,6 +13,6 @@ RUN mkdir -p /app/integration-test/; cd /app/integration-test \
 
 # Install Ginkgo binary for fast integration test feedback. Keep in sync with 
 # ministryofjustice/cloud-platform-infrastructure tests/go.mod
-RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.17.1
+RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.19.0
 
 ENV PATH="/root/go/bin:${PATH}"


### PR DESCRIPTION
This PR bumps the ginkgo dependency library used by concourse pipeline to match infrastructure go.mod
https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/go.mod#L12

This will fix the below pipeline error 

```
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.17.1
  Mismatched package versions found:
    2.19.0 used by test
```
